### PR TITLE
Added permchain and python-multipart libraries to requirements.txt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,5 @@ langchain-cli
 -e packages/agent-executor
 langchain>=0.0.331
 langserve>=0.0.23
+permchain
+python-multipart


### PR DESCRIPTION
This PR fixes some dependencies errors when trying to build the backend and running `langchain serve --port=8100`

Missing dependencies in requirements.txt
- permchain
- python-multipart
I could also specify a version to use here.

I have completed the form and signed the CLA.

Let me know if there is anything more to do from my side!
