### PR TITLE
Improved API doc 

### DIFF
--- a/API.md
+++ b/API.md
@@ -36,9 +36,10 @@ The config parameters allows you to set the LLM used, the instructions of the as
   "name": "bar",
   "config": {
     "configurable": {
-      "agent_type": "GPT 3.5 Turbo",
-      "system_message": "You are a helpful assistant",
-      "tools": ["Wikipedia"]
+      "type": "agent",
+      "type==agent/agent_type": "GPT 3.5 Turbo",
+      "type==agent/system_message": "You are a helpful assistant",
+      "type==agent/tools": ["Wikipedia"]
   },
   "public": True
 }


### PR DESCRIPTION
I spend quite some time figuring out how to create an assistant with specific instructions and tools. I don't want anyone else to also spend time so I updated the documentation.

- Fixed the typo in the doc, to create an assistant, we need a POST request (and not PUT)
- Added some description on how to specify instructions, LLMs and tools to an assistant