### PR TITLE
Fix issues in backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,9 +7,7 @@ RUN apt-get update && apt-get install -y libmagic1 && rm -rf /var/lib/apt/lists/
 # Set the working directory
 WORKDIR /backend
 
-COPY . .
-
-RUN rm poetry.lock
+COPY backend/ .
 
 RUN pip install .
 


### PR DESCRIPTION
Docker compose is failing when building the backend.
 - The relative path to the backend code is wrong
 - The poetry.lock file is missing