### PR TITLE
Fix backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,10 +4,10 @@ FROM python:3.11
 # Install system dependencies
 RUN apt-get update && apt-get install -y libmagic1 && rm -rf /var/lib/apt/lists/*
 
+COPY . .
+
 # Set the working directory
 WORKDIR /backend
-
-COPY . .
 
 RUN rm poetry.lock
 


### PR DESCRIPTION
See discussion here: https://github.com/langchain-ai/opengpts/issues/109

Issue is:
```
------
 > [backend 5/6] RUN rm poetry.lock:
0.125 rm: cannot remove 'poetry.lock': No such file or directory
------
failed to solve: process "/bin/sh -c rm poetry.lock" did not complete successfully: exit code: 1
```