### PR TITLE
Fixing public link issue on page reload

### DIFF
--- a/frontend/src/components/Config.tsx
+++ b/frontend/src/components/Config.tsx
@@ -160,7 +160,8 @@ function MultiOptionField(props: {
 }
 
 function PublicLink(props: { assistantId: string }) {
-  const link = window.location.href + "?shared_id=" + props.assistantId;
+  const currentLink = window.location.href;
+  const link = currentLink.includes('shared_id=') ? currentLink : currentLink + "?shared_id=" + props.assistantId;
   return (
     <div className="flex rounded-md shadow-sm mb-4">
       <button


### PR DESCRIPTION
There was a bug in the Public URL feature that caused the shared_id to be added repeatedly when the page loaded. (http://localhost:5173/?shared_id=474f465e-9701-4bdd-90a4- 392ac966ce94?shared_id=474f465e-9701-4bdd-90a4-392ac966ce94)

To rectify this issue, we implemented a flag in the code to generate the public link only if it is not already available. If the link exists, it will utilize the existing one.