### PR TITLE
Fix deprecated flag in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,9 @@ WORKDIR /backend
 COPY ./backend/pyproject.toml ./backend/poetry.lock* ./
 
 # Install dependencies
-# --no-dev: Skip installing packages listed in the [tool.poetry.dev-dependencies] section
+# --only main: Skip installing packages listed in the [tool.poetry.dev-dependencies] section
 RUN poetry config virtualenvs.create false \
-    && poetry install --no-interaction --no-ansi --no-dev
+    && poetry install --no-interaction --no-ansi --only main
 
 # Copy the rest of backend
 COPY ./backend .

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /backend
 COPY pyproject.toml poetry.lock* ./
 
 # Install dependencies
-# --no-dev: Skip installing packages listed in the [tool.poetry.dev-dependencies] section
+# --only main: Skip installing packages listed in the [tool.poetry.dev-dependencies] section
 RUN poetry config virtualenvs.create false \
-    && poetry install --no-interaction --no-ansi --no-dev
+    && poetry install --no-interaction --no-ansi --only main
 
 # Copy the rest of application code
 COPY . .


### PR DESCRIPTION
This pull request updates the Dockerfile to replace the deprecated flag "--no-dev" with "--only main" in the "poetry install" command.

This ensures that only the main dependencies are installed and not the dev dependencies.

Fix: #237