### PR TITLE
Streamline Quickstart Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,59 @@ Because this is open source, if you do not like those architectures or want to m
 - [GPTs: a simple hosted version](https://opengpts-example-vz4y4ooboq-uc.a.run.app/)
 - [Assistants API: a getting started guide](API.md)
 
+## Quickstart with Docker
+
+This project supports a Docker-based setup, streamlining installation and execution. It automatically builds images for the frontend and backend and sets up Redis using docker-compose.
+
+### Quick Start
+
+0.  **Prerequisites:**  
+    Ensure you have Docker and docker-compose installed on your system.
+
+
+1. **Clone the Repository:**  
+   Obtain the project files by cloning the repository.
+
+   ```
+   git clone https://github.com/langchain-ai/opengpts.git
+   cd opengpts
+   ```
+
+2. **Set Up Environment Variables:**  
+   Create a `.env` file in the root directory of the project and add the following environment variables:
+
+   ```shell
+   # At least one language model API key is required
+   OPENAI_API_KEY=sk-...
+   # LANGCHAIN_TRACING_V2=true
+   # LANGCHAIN_API_KEY=...
+   ```
+
+   Replace `sk-...` with your OpenAI API key and `...` with your LangChain API key.
+
+
+3. **Run with Docker Compose:**  
+   In the root directory of the project, execute:
+
+   ```
+   docker compose up
+   ```
+
+   This command builds the Docker images for the frontend and backend from their respective Dockerfiles and starts all necessary services, including Redis.
+
+
+4. **Access the Application:**  
+   With the services running, access the frontend at [http://localhost:5173](http://localhost:5173), substituting `5173` with the designated port number.
+
+
+5. **Rebuilding After Changes:**  
+   If you make changes to either the frontend or backend, rebuild the Docker images to reflect these changes. Run:
+   ```
+   docker compose up --build
+   ```
+   This command rebuilds the images with your latest changes and restarts the services.
+
+
 ## Quickstart without Docker
 
 ### Start the backend
@@ -109,46 +162,6 @@ yarn dev
 ```
 
 Navigate to [http://localhost:5173/](http://localhost:5173/) and enjoy!
-
-## Installation and Running with Docker
-
-This project supports a Docker-based setup, streamlining installation and execution. It automatically builds images for the frontend and backend and sets up Redis using docker-compose.
-
-### Quick Start
-
-1. **Clone the Repository:**  
-   Obtain the project files by cloning the repository.
-
-   ```
-   git clone https://github.com/langchain-ai/opengpts.git
-   cd opengpts
-   ```
-
-2. **Run with Docker Compose:**  
-   In the root directory of the project, execute:
-
-   ```
-   docker compose up
-   ```
-
-   This command builds the Docker images for the frontend and backend from their respective Dockerfiles and starts all necessary services, including Redis.
-
-3. **Access the Application:**  
-   With the services running, access the frontend at [http://localhost:5173](http://localhost:5173), substituting `5173` with the designated port number.
-
-4. **Rebuilding After Changes:**  
-   If you make changes to either the frontend or backend, rebuild the Docker images to reflect these changes. Run:
-   ```
-   docker compose up --build
-   ```
-   This command rebuilds the images with your latest changes and restarts the services.
-
-### Note
-
-- Ensure Docker and docker-compose are installed on your system.
-- Adjust the `.env` file as required for specific environment configurations.
-
----
 
 ## Features
 


### PR DESCRIPTION
## What?

1. Move Docker Quickstart instructions up so it comes before non-Docker Quickstart.
2. Establish/document pre-requisites early.
3. Establish/document minimal config for Docker launch.

## Why?
I'm a firm believer in the idea that open source project docs should provide docs that can get a new user from zero to "Hello World" in under 15 minutes or so (time resolving and downloading deps doesn't count. ;) ). 

This is just a quick change that might reduce friction for new users/contributors.

