### PR TITLE
Update agent_types path?

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ We have exposed four agent types by default:
 
 We will work to add more when we have confidence they can work well.
 
-If you want to add your own LLM or agent configuration, or want to edit the existing ones, you can find them in `backend/packages/gizmo-agent/gizmo_agent/agent_types`
+If you want to add your own LLM or agent configuration, or want to edit the existing ones, you can find them in `backend/app/agent_types`
 
 #### Claude 2
 


### PR DESCRIPTION
I was trying to see how to implement a custom agent, but that path didn't exist, so I wonder if it should be updated.