### PR TITLE
Expand non-Docker Quickstart Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Because this is open source, if you do not like those architectures or want to m
 
 ## Quickstart with Docker
 
-This project supports a Docker-based setup, streamlining installation and execution. It automatically builds images for the frontend and backend and sets up Postgres using docker-compose.
+This project supports a Docker-based setup, streamlining installation and execution. It automatically builds images for 
+the frontend and backend and sets up Postgres using docker-compose.
 
-### Quick Start
 
 1. **Prerequisites:**  
     Ensure you have Docker and docker-compose installed on your system.
@@ -51,7 +51,8 @@ This project supports a Docker-based setup, streamlining installation and execut
    ```
 
 3. **Set Up Environment Variables:**  
-   Create a `.env` file in the root directory of the project by copying `.env.example` as a template, and add the following environment variables:
+   Create a `.env` file in the root directory of the project by copying `.env.example` as a template, and add the 
+   following environment variables:
    ```shell
    # At least one language model API key is required
    OPENAI_API_KEY=sk-...
@@ -75,10 +76,12 @@ This project supports a Docker-based setup, streamlining installation and execut
    docker compose up
    ```
 
-   This command builds the Docker images for the frontend and backend from their respective Dockerfiles and starts all necessary services, including Postgres.
+   This command builds the Docker images for the frontend and backend from their respective Dockerfiles and starts all 
+   necessary services, including Postgres.
 
 5. **Access the Application:**  
-   With the services running, access the frontend at [http://localhost:5173](http://localhost:5173), substituting `5173` with the designated port number.
+   With the services running, access the frontend at [http://localhost:5173](http://localhost:5173), substituting `5173` with the 
+   designated port number.
 
 
 6. **Rebuilding After Changes:**  
@@ -91,38 +94,89 @@ This project supports a Docker-based setup, streamlining installation and execut
 
 ## Quickstart without Docker
 
-### Start the backend
+**Prerequisites**
+The following instructions assume you have Python 3.11+ installed on your system. We strongly recommend using a virtual 
+environment to manage dependencies.
 
-**Install requirements**
-
-The backend service uses [poetry](https://python-poetry.org/docs/#installation) to manage dependencies.
-It assumes libmagic to be [installed](https://github.com/ahupp/python-magic?tab=readme-ov-file#installation) in your host system.
-
+For example, if you are using `pyenv`, you can create a new virtual environment with:
 ```shell
-cd backend
-poetry install
+pyenv install 3.11
+pyenv virtualenv 3.11 opengpts
+pyenv activate opengpts
 ```
 
-**Set up persistence layer**
+Once your Python environment is set up, you can install the project dependencies:
+
+The backend service uses [poetry](https://python-poetry.org/docs/#installation) to manage dependencies.
+It assumes libmagic to be [installed](https://github.com/ahupp/python-magic?tab=readme-ov-file#installation) in your 
+host system.
+
+```shell 
+pip install poetry
+pip install libmagic
+pip install langchain-community
+brew install libmagic
+```
+
+**Install Postgres and the Postgres Vector Extension**
+```
+brew install postgresql pgvector
+brew services start postgresql
+```
+
+**Configure persistence layer**
 
 The backend uses Postgres for saving agent configurations and chat message history.
 In order to use this, you need to set the following environment variables:
 
 ```shell
-export POSTGRES_HOST=...
-export POSTGRES_PORT=...
-export POSTGRES_DB=...
-export POSTGRES_USER=...
+export POSTGRES_HOST=localhost
+export POSTGRES_PORT=5432
+export POSTGRES_DB=opengpts
+export POSTGRES_USER=postgres
 export POSTGRES_PASSWORD=...
 ```
 
-Migrations are managed with [golang-migrate](https://github.com/golang-migrate/migrate). Ensure it's installed on your machine and use `make migrate` to run all migrations. For those opting to run the project via Docker, the Dockerfile already includes golang-migrate.
+**Creeate the database**
+```shell
+createdb opengpts
+```
 
-**Set up vector database**
+**Connect to the database and create the `postgres` role**
+```shell
+psql -d opengpts
+```
 
-The backend by default also uses Postgres as a vector database,
+```sql
+CREATE ROLE postgres WITH LOGIN SUPERUSER CREATEDB CREATEROLE;
+```
+
+**Install Golang Migrate**
+
+Database migrations are managed with [golang-migrate](https://github.com/golang-migrate/migrate). 
+
+On MacOS, you can install it with `brew install golang-migrate`. Instructions for other OSs or the Golang toolchain, 
+can be found [here](https://github.com/golang-migrate/migrate/blob/master/cmd/migrate/README.md#installation).
+
+Once `golang-migrate` is installed, you can run all the migrations with:
+```shell
+make migrate
+```
+
+This will enable the backend to use Postgres as a vector database and create the initial tables.
+
+
+**Install backend dependencies**
+```shell
+cd backend
+poetry install
+```
+
+
+**Alternate vector databases**
+
+The instructions above use Postgres as a vector database,
 although you can easily switch this out to use any of the 50+ vector databases in LangChain.
-If you are using Postgres as a vectorstore, the above environment variables should work.
 
 **Set up language models**
 
@@ -166,8 +220,8 @@ make start
 
 ```shell
 cd frontend
-yarn
-yarn dev
+npm install
+npm run dev
 ```
 
 Navigate to [http://localhost:5173/](http://localhost:5173/) and enjoy!
@@ -218,41 +272,61 @@ You can also use the underlying APIs directly and build a custom UI yourself sho
 ### Cognitive Architecture
 
 This refers to the logic of how the GPT works.
-There are currently three different architectures supported, but because they are all written in LangGraph, it is very easy to modify them or add your own.
+There are currently three different architectures supported, but because they are all written in LangGraph, it is very 
+easy to modify them or add your own.
 
 The three different architectures supported are assistants, RAG, and chatbots.
 
 **Assistants**
 
-Assistants can be equipped with arbitrary amount of tools and use an LLM to decide when to use them. This makes them the most flexible choice, but they work well with fewer models and can be less reliable.
+Assistants can be equipped with arbitrary amount of tools and use an LLM to decide when to use them. This makes them 
+the most flexible choice, but they work well with fewer models and can be less reliable.
 
 When creating an assistant, you specify a few things.
 
-First, you choose the language model to use. Only a few language models can be used reliably well: GPT-3.5, GPT-4, Claude, and Gemini.
+First, you choose the language model to use. Only a few language models can be used reliably well: GPT-3.5, GPT-4, 
+Claude, and Gemini.
 
-Second, you choose the tools to use. These can be predefined tools OR a retriever constructed from uploaded files. You can choose however many you want.
+Second, you choose the tools to use. These can be predefined tools OR a retriever constructed from uploaded files. You 
+can choose however many you want.
 
-The cognitive architecture can then be thought of as a loop. First, the LLM is called to determine what (if any) actions to take. If it decides to take actions, then those actions are executed and it loops back. If no actions are decided to take, then the response of the LLM is the final response, and it finishes the loop.
+The cognitive architecture can then be thought of as a loop. First, the LLM is called to determine what (if any) 
+actions to take. If it decides to take actions, then those actions are executed and it loops back. If no actions are 
+decided to take, then the response of the LLM is the final response, and it finishes the loop.
 
 ![](_static/agent.png)
 
-This can be a really powerful and flexible architecture. This is probably closest to how us humans operate. However, these also can be not super reliable, and generally only work with the more performant models (and even then they can mess up). Therefore, we introduced a few simpler architecures.
+This can be a really powerful and flexible architecture. This is probably closest to how us humans operate. However, 
+these also can be not super reliable, and generally only work with the more performant models (and even then they can 
+mess up). Therefore, we introduced a few simpler architecures.
 
 **RAGBot**
 
-One of the big use cases of the GPT store is uploading files and giving the bot knowledge of those files. What would it mean to make an architecture more focused on that use case?
+One of the big use cases of the GPT store is uploading files and giving the bot knowledge of those files. What would it 
+mean to make an architecture more focused on that use case?
 
-We added RAGBot - a retrieval-focused GPT with a straightforward architecture. First, a set of documents are retrieved. Then, those documents are passed in the system message to a separate call to the language model so it can respond.
+We added RAGBot - a retrieval-focused GPT with a straightforward architecture. First, a set of documents are retrieved. 
+Then, those documents are passed in the system message to a separate call to the language model so it can respond.
 
-Compared to assistants, it is more structured (but less powerful). It ALWAYS looks up something - which is good if you know you want to look things up, but potentially wasteful if the user is just trying to have a normal conversation. Also importantly, this only looks up things once - so if it doesn’t find the right results then it will yield a bad result (compared to an assistant, which could  decide to look things up again).
+Compared to assistants, it is more structured (but less powerful). It ALWAYS looks up something - which is good if you 
+know you want to look things up, but potentially wasteful if the user is just trying to have a normal conversation. 
+Also importantly, this only looks up things once - so if it doesn’t find the right results then it will yield a bad 
+result (compared to an assistant, which could  decide to look things up again).
 
 ![](_static/rag.png)
 
-Despite this being a more simple architecture, it is good for a few reasons. First, because it is simpler it can work pretty well with a wider variety of models (including lots of open source models). Second, if you have a use case where you don’t NEED the flexibility of an assistant (eg you know users will be looking up information every time) then it can be more focused. And third, compared to the final architecture below it can use external knowledge.
+Despite this being a more simple architecture, it is good for a few reasons. First, because it is simpler it can work 
+pretty well with a wider variety of models (including lots of open source models). Second, if you have a use case where 
+you don’t NEED the flexibility of an assistant (eg you know users will be looking up information every time) then it 
+can be more focused. And third, compared to the final architecture below it can use external knowledge.
 
 **ChatBot**
 
-The final architecture is dead simple - just a call to a language model, parameterized by a system message. This allows the GPT to take on different personas and characters. This is clearly far less powerful than Assistants or RAGBots (which have access to external sources of data/computation) - but it’s still valuable! A lot of popular GPTs are just system messages at the end of the day, and CharacterAI is crushing it despite largely just being system messages as well.
+The final architecture is dead simple - just a call to a language model, parameterized by a system message. This allows 
+the GPT to take on different personas and characters. This is clearly far less powerful than Assistants or RAGBots 
+(which have access to external sources of data/computation) - but it’s still valuable! A lot of popular GPTs are just 
+system messages at the end of the day, and CharacterAI is crushing it despite largely just being system messages as 
+well.
 
 ![](_static/chatbot.png)
 
@@ -271,7 +345,8 @@ We have exposed four agent types by default:
 
 We will work to add more when we have confidence they can work well.
 
-If you want to add your own LLM or agent configuration, or want to edit the existing ones, you can find them in `backend/app/agent_types`
+If you want to add your own LLM or agent configuration, or want to edit the existing ones, you can find them in 
+`backend/app/agent_types`
 
 #### Claude 2
 
@@ -294,7 +369,8 @@ export AZURE_OPENAI_DEPLOYMENT_NAME=...
 
 #### Amazon Bedrock
 
-If using Amazon Bedrock, you either have valid credentials in `~/.aws/credentials` or set the following environment variables:
+If using Amazon Bedrock, you either have valid credentials in `~/.aws/credentials` or set the following environment 
+variables:
 
 ```shell
 export AWS_ACCESS_KEY_ID=...
@@ -307,7 +383,8 @@ One of the big benefits of having this be open source is that you can more easil
 
 In practice, most teams we see define their own tools.
 This is easy to do within LangChain.
-See [this guide](https://python.langchain.com/docs/modules/agents/tools/custom_tools) for details on how to best do this.
+See [this guide](https://python.langchain.com/docs/modules/agents/tools/custom_tools) for details on how to best do 
+this.
 
 If you want to use some preconfigured tools, these include:
 
@@ -419,9 +496,11 @@ You can deploy to GCP Cloud Run using the following command:
 First create a `.env.gcp.yaml` file with the contents from `.env.gcp.yaml.example` and fill in the values. Then run:
 
 ```shell
-gcloud run deploy opengpts --source . --port 8000 --env-vars-file .env.gcp.yaml --allow-unauthenticated --region us-central1 --min-instances 1
+gcloud run deploy opengpts --source . --port 8000 --env-vars-file .env.gcp.yaml --allow-unauthenticated \
+--region us-central1 --min-instances 1
 ```
 
 ### Deploy in Kubernetes
 
-We have a Helm chart for deploying the backend to Kubernetes. You can find more information here: [README.md](https://github.com/langchain-ai/helm/tree/main/charts/open-gpts)
+We have a Helm chart for deploying the backend to Kubernetes. You can find more information here: 
+[README.md](https://github.com/langchain-ai/helm/tree/main/charts/open-gpts)

--- a/backend/app/parsing.py
+++ b/backend/app/parsing.py
@@ -1,8 +1,8 @@
 """Module contains logic for parsing binary blobs into text."""
-from langchain.document_loaders.parsers import BS4HTMLParser, PDFMinerParser
-from langchain.document_loaders.parsers.generic import MimeTypeBasedParser
-from langchain.document_loaders.parsers.msword import MsWordParser
-from langchain.document_loaders.parsers.txt import TextParser
+from langchain_community.document_loaders.parsers import BS4HTMLParser, PDFMinerParser
+from langchain_community.document_loaders.parsers.generic import MimeTypeBasedParser
+from langchain_community.document_loaders.parsers.msword import MsWordParser
+from langchain_community.document_loaders.parsers.txt import TextParser
 
 HANDLERS = {
     "application/pdf": PDFMinerParser(),

--- a/backend/app/server.py
+++ b/backend/app/server.py
@@ -39,7 +39,7 @@ ui_dir = str(ROOT / "ui")
 if os.path.exists(ui_dir):
     app.mount("", StaticFiles(directory=ui_dir, html=True), name="ui")
 else:
-    logger.warn("No UI directory found, serving API only.")
+    logger.warning("No UI directory found, serving API only.")
 
 if __name__ == "__main__":
     import uvicorn

--- a/backend/tests/unit_tests/agent_executor/test_parsing.py
+++ b/backend/tests/unit_tests/agent_executor/test_parsing.py
@@ -1,7 +1,7 @@
 """Test parsing logic."""
 import mimetypes
 
-from langchain.document_loaders import Blob
+from langchain_community.document_loaders import Blob
 
 from app.parsing import MIMETYPE_BASED_PARSER, SUPPORTED_MIMETYPES
 from tests.unit_tests.fixtures import get_sample_paths


### PR DESCRIPTION
# What?

1. Expand non-Docker quickstart documentation to more thoroughly cover dependency installation and database configuration.
2.  Fix a few `langchain_community` imports and other deprecations.
3. Hard-wrap README markdown to make it easier to digest as text only.

# Why?
Increase the speed with which new users and developers can get started.