### PR TITLE
remove assistant_id from run payload

### DIFF
--- a/backend/app/checkpoint.py
+++ b/backend/app/checkpoint.py
@@ -1,10 +1,10 @@
-from datetime import datetime
 import pickle
+from datetime import datetime
 from typing import AsyncIterator, Optional
 
 from langchain_core.runnables import ConfigurableFieldSpec, RunnableConfig
 from langgraph.checkpoint import BaseCheckpointSaver
-from langgraph.checkpoint.base import Checkpoint, CheckpointTuple, CheckpointThreadTs
+from langgraph.checkpoint.base import Checkpoint, CheckpointThreadTs, CheckpointTuple
 
 from app.lifespan import get_pg_pool
 

--- a/backend/app/upload.py
+++ b/backend/app/upload.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import os
 from typing import Any, BinaryIO, List, Optional
 
-from langchain_text_splitters import RecursiveCharacterTextSplitter, TextSplitter
 from langchain_community.document_loaders.blob_loaders.schema import Blob
 from langchain_community.vectorstores.pgvector import PGVector
 from langchain_core.runnables import (
@@ -21,6 +20,7 @@ from langchain_core.runnables import (
 )
 from langchain_core.vectorstores import VectorStore
 from langchain_openai import OpenAIEmbeddings
+from langchain_text_splitters import RecursiveCharacterTextSplitter, TextSplitter
 
 from app.ingest import ingest_blob
 from app.parsing import MIMETYPE_BASED_PARSER

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,11 +27,7 @@ function App() {
   const { currentChat, assistantConfig, isLoading } = useThreadAndAssistant();
 
   const startTurn = useCallback(
-    async (
-      message: MessageWithFiles | null,
-      thread_id: string,
-      assistant_id: string,
-    ) => {
+    async (message: MessageWithFiles | null, thread_id: string) => {
       const files = message?.files || [];
       if (files.length > 0) {
         const formData = files.reduce((formData, file) => {
@@ -58,7 +54,6 @@ function App() {
               },
             ]
           : null,
-        assistant_id,
         thread_id,
       );
     },
@@ -69,7 +64,7 @@ function App() {
     async (config: ConfigInterface, message: MessageWithFiles) => {
       const chat = await createChat(message.message, config.assistant_id);
       navigate(`/thread/${chat.thread_id}`);
-      return startTurn(message, chat.thread_id, chat.assistant_id);
+      return startTurn(message, chat.thread_id);
     },
     [createChat, navigate, startTurn],
   );

--- a/frontend/src/hooks/useStreamState.tsx
+++ b/frontend/src/hooks/useStreamState.tsx
@@ -11,11 +11,7 @@ export interface StreamState {
 
 export interface StreamStateProps {
   stream: StreamState | null;
-  startStream: (
-    input: Message[] | null,
-    assistant_id: string,
-    thread_id: string,
-  ) => Promise<void>;
+  startStream: (input: Message[] | null, thread_id: string) => Promise<void>;
   stopStream?: (clear?: boolean) => void;
 }
 
@@ -24,11 +20,7 @@ export function useStreamState(): StreamStateProps {
   const [controller, setController] = useState<AbortController | null>(null);
 
   const startStream = useCallback(
-    async (
-      input: Message[] | null,
-      assistant_id: string,
-      thread_id: string,
-    ) => {
+    async (input: Message[] | null, thread_id: string) => {
       const controller = new AbortController();
       setController(controller);
       setCurrent({ status: "inflight", messages: input || [], merge: true });
@@ -37,7 +29,7 @@ export function useStreamState(): StreamStateProps {
         signal: controller.signal,
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ input, assistant_id, thread_id }),
+        body: JSON.stringify({ input, thread_id }),
         openWhenHidden: true,
         onmessage(msg) {
           if (msg.event === "data") {


### PR DESCRIPTION
No need to know what assistant id. Thread id is unique and backend can figure out everything else.

This makes it simpler to use the API as less needs to be known.