### PR TITLE
initial implementation of Ollama LLM

### DIFF
--- a/backend/app/agent.py
+++ b/backend/app/agent.py
@@ -17,8 +17,8 @@ from app.llms import (
     get_anthropic_llm,
     get_google_llm,
     get_mixtral_fireworks,
-    get_openai_llm,
     get_ollama_llm,
+    get_openai_llm,
 )
 from app.retrieval import get_retrieval_executor
 from app.tools import (

--- a/backend/app/agent.py
+++ b/backend/app/agent.py
@@ -18,6 +18,7 @@ from app.llms import (
     get_google_llm,
     get_mixtral_fireworks,
     get_openai_llm,
+    get_ollama_llm,
 )
 from app.retrieval import get_retrieval_executor
 from app.tools import (
@@ -63,6 +64,7 @@ class AgentType(str, Enum):
     CLAUDE2 = "Claude 2"
     BEDROCK_CLAUDE2 = "Claude 2 (Amazon Bedrock)"
     GEMINI = "GEMINI"
+    OLLAMA = "Ollama"
 
 
 DEFAULT_SYSTEM_MESSAGE = "You are a helpful assistant."
@@ -106,6 +108,12 @@ def get_agent_executor(
         return get_google_agent_executor(
             tools, llm, system_message, interrupt_before_action, CHECKPOINTER
         )
+    elif agent == AgentType.OLLAMA:
+        llm = get_ollama_llm()
+        return get_openai_agent_executor(
+            tools, llm, system_message, interrupt_before_action, CHECKPOINTER
+        )
+
     else:
         raise ValueError("Unexpected agent type")
 
@@ -175,6 +183,7 @@ class LLMType(str, Enum):
     BEDROCK_CLAUDE2 = "Claude 2 (Amazon Bedrock)"
     GEMINI = "GEMINI"
     MIXTRAL = "Mixtral"
+    OLLAMA = "Ollama"
 
 
 def get_chatbot(
@@ -195,6 +204,8 @@ def get_chatbot(
         llm = get_google_llm()
     elif llm_type == LLMType.MIXTRAL:
         llm = get_mixtral_fireworks()
+    elif llm_type == LLMType.OLLAMA:
+        llm = get_ollama_llm()
     else:
         raise ValueError("Unexpected llm type")
     return get_chatbot_executor(llm, system_message, CHECKPOINTER)
@@ -270,6 +281,8 @@ class ConfigurableRetrieval(RunnableBinding):
             llm = get_google_llm()
         elif llm_type == LLMType.MIXTRAL:
             llm = get_mixtral_fireworks()
+        elif llm_type == LLMType.OLLAMA:
+            llm = get_ollama_llm()
         else:
             raise ValueError("Unexpected llm type")
         chatbot = get_retrieval_executor(llm, retriever, system_message, CHECKPOINTER)

--- a/backend/app/llms.py
+++ b/backend/app/llms.py
@@ -82,6 +82,7 @@ def get_google_llm():
 def get_mixtral_fireworks():
     return ChatFireworks(model="accounts/fireworks/models/mixtral-8x7b-instruct")
 
+
 @lru_cache(maxsize=1)
 def get_ollama_llm():
     model_name = os.environ.get("OLLAMA_MODEL")

--- a/backend/app/llms.py
+++ b/backend/app/llms.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 import boto3
 import httpx
 from langchain_community.chat_models import BedrockChat, ChatAnthropic, ChatFireworks
+from langchain_community.chat_models.ollama import ChatOllama
 from langchain_google_vertexai import ChatVertexAI
 from langchain_openai import AzureChatOpenAI, ChatOpenAI
 
@@ -80,3 +81,14 @@ def get_google_llm():
 @lru_cache(maxsize=1)
 def get_mixtral_fireworks():
     return ChatFireworks(model="accounts/fireworks/models/mixtral-8x7b-instruct")
+
+@lru_cache(maxsize=1)
+def get_ollama_llm():
+    model_name = os.environ.get("OLLAMA_MODEL")
+    if not model_name:
+        model_name = "llama2"
+    ollama_base_url = os.environ.get("OLLAMA_BASE_URL")
+    if not ollama_base_url:
+        ollama_base_url = "http://localhost:11434"
+
+    return ChatOllama(model_name=model_name, ollama_base_url=ollama_base_url)

--- a/backend/app/upload.py
+++ b/backend/app/upload.py
@@ -20,7 +20,7 @@ from langchain_core.runnables import (
     RunnableSerializable,
 )
 from langchain_core.vectorstores import VectorStore
-from langchain_openai import OpenAIEmbeddings, AzureOpenAIEmbeddings
+from langchain_openai import AzureOpenAIEmbeddings, OpenAIEmbeddings
 from langchain_text_splitters import RecursiveCharacterTextSplitter, TextSplitter
 
 from app.ingest import ingest_blob


### PR DESCRIPTION
# What?

Add an option to use Ollama LLMs for agents

New "Ollama" optyion:
<img width="412" alt="Screenshot 2024-04-06 at 7 23 41 PM" src="https://github.com/langchain-ai/opengpts/assets/260896/f42def1b-3a06-4694-b66a-e94e3aa38ee4">

Bot created with the Ollama LLM:
<img width="306" alt="Screenshot 2024-04-06 at 7 24 04 PM" src="https://github.com/langchain-ai/opengpts/assets/260896/dada864f-35a9-419c-a259-bc4930812401">

Test Llama2 LLM:
<img width="948" alt="Screenshot 2024-04-06 at 7 59 21 PM" src="https://github.com/langchain-ai/opengpts/assets/260896/8b27c89c-7f30-429b-921e-07b6059536e1">

Test OpenChat LLM:
<img width="895" alt="Screenshot 2024-04-06 at 8 26 10 PM" src="https://github.com/langchain-ai/opengpts/assets/260896/f1580df0-62c1-4496-a1cd-5a72e40bd1b7">

For now, it only supports one Ollama Model. Future Pull Requests will address this shortcoming.

Configuration is currently driven by environment variables:

```shell
 export OLLAMA_MODEL=openchat
 export OLLAMA_BASE_URL=http://localhost:11434/
 ```

I will follow up with PRs that model configuration multi-model, and more dynamic. 
