### PR TITLE
Fix ChatOllama model parameter

### DIFF
--- a/backend/app/llms.py
+++ b/backend/app/llms.py
@@ -92,4 +92,4 @@ def get_ollama_llm():
     if not ollama_base_url:
         ollama_base_url = "http://localhost:11434"
 
-    return ChatOllama(model_name=model_name, ollama_base_url=ollama_base_url)
+    return ChatOllama(model=model_name, ollama_base_url=ollama_base_url)


### PR DESCRIPTION
# What?
Fix `model` parameter to ChatOllama constructor.

# Why?
The model parameter name to ChatOllama was wrong, effectively pinning it to the default of "llama2" and preventing usage of other Ollama models.