### PR TITLE
fix: Action Server: do not cache tool definitions

### DIFF
--- a/backend/app/tools.py
+++ b/backend/app/tools.py
@@ -271,7 +271,6 @@ def _get_tavily_answer():
     return _TavilyAnswer(api_wrapper=tavily_search)
 
 
-@lru_cache(maxsize=1)
 def _get_action_server(**kwargs: ActionServerConfig):
     toolkit = ActionServerToolkit(url=kwargs["url"], api_key=kwargs["api_key"])
     tools = toolkit.get_tools()


### PR DESCRIPTION
Action Server tool definitions are based on openapi spec that may change.
Do not cache the definitions over requests.