### PR TITLE
Update backend API interfaces to be agnostic to messages list (i.e. `MessageGraph`)

### DIFF
--- a/API.md
+++ b/API.md
@@ -77,7 +77,7 @@ We can check the thread, and see that it is currently empty:
 ```python
 import requests
 requests.get(
-    'http://127.0.0.1:8100/threads/231dc7f3-33ee-4040-98fe-27f6e2aa8b2b/messages', 
+    'http://127.0.0.1:8100/threads/231dc7f3-33ee-4040-98fe-27f6e2aa8b2b/state', 
     cookies= {"opengpts_user_id": "foo"}
 ).content
 ```
@@ -90,9 +90,9 @@ Let's add a message to the thread!
 ```python
 import requests
 requests.post(
-    'http://127.0.0.1:8100/threads/231dc7f3-33ee-4040-98fe-27f6e2aa8b2b/messages', 
+    'http://127.0.0.1:8100/threads/231dc7f3-33ee-4040-98fe-27f6e2aa8b2b/state', 
     cookies= {"opengpts_user_id": "foo"}, json={
-        "messages": [{
+        "values": [{
             "content": "hi! my name is bob",
             "type": "human",
         }]
@@ -105,12 +105,12 @@ If we now run the command to see the thread, we can see that there is now a mess
 ```python
 import requests
 requests.get(
-    'http://127.0.0.1:8100/threads/231dc7f3-33ee-4040-98fe-27f6e2aa8b2b/messages', 
+    'http://127.0.0.1:8100/threads/231dc7f3-33ee-4040-98fe-27f6e2aa8b2b/state', 
     cookies= {"opengpts_user_id": "foo"}
 ).content
 ```
 ```shell
-b'{"messages":[{"content":"hi! my name is bob","additional_kwargs":{},"type":"human","example":false}]}'
+b'{"values":[{"content":"hi! my name is bob","additional_kwargs":{},"type":"human","example":false}],"next":[]}'
 ```
 
 ## Run the assistant on that thread
@@ -133,10 +133,10 @@ If we now check the thread, we can see (after a bit) that there is a message fro
 
 ```python
 import requests
-requests.get('http://127.0.0.1:8100/threads/231dc7f3-33ee-4040-98fe-27f6e2aa8b2b/messages', cookies= {"opengpts_user_id": "foo"}).content
+requests.get('http://127.0.0.1:8100/threads/231dc7f3-33ee-4040-98fe-27f6e2aa8b2b/state', cookies= {"opengpts_user_id": "foo"}).content
 ```
 ```shell
-b'{"messages":[{"content":"hi! my name is bob","additional_kwargs":{},"type":"human","example":false},{"content":"Hello, Bob! How can I assist you today?","additional_kwargs":{"agent":{"return_values":{"output":"Hello, Bob! How can I assist you today?"},"log":"Hello, Bob! How can I assist you today?","type":"AgentFinish"}},"type":"ai","example":false}]}'
+b'{"values":[{"content":"hi! my name is bob","additional_kwargs":{},"type":"human","example":false},{"content":"Hello, Bob! How can I assist you today?","additional_kwargs":{"agent":{"return_values":{"output":"Hello, Bob! How can I assist you today?"},"log":"Hello, Bob! How can I assist you today?","type":"AgentFinish"}},"type":"ai","example":false}],"next":[]}'
 ```
 
 ## Run the assistant on the thread with new messages
@@ -153,8 +153,7 @@ requests.post('http://127.0.0.1:8100/runs', cookies= {"opengpts_user_id": "foo"}
         "messages": [{
             "content": "whats my name? respond in spanish",
             "type": "human",
-        }
-        ]
+        }]
     }
 }).content
 ```
@@ -163,11 +162,11 @@ Then, if we call the threads endpoint after a bit we can see the human message -
 
 ```python
 import requests
-requests.get('http://127.0.0.1:8100/threads/231dc7f3-33ee-4040-98fe-27f6e2aa8b2b/messages', cookies= {"opengpts_user_id": "foo"}).content
+requests.get('http://127.0.0.1:8100/threads/231dc7f3-33ee-4040-98fe-27f6e2aa8b2b/state', cookies= {"opengpts_user_id": "foo"}).content
 ```
 
 ```shell
-b'{"messages":[{"content":"hi! my name is bob","additional_kwargs":{},"type":"human","example":false},{"content":"Hello, Bob! How can I assist you today?","additional_kwargs":{"agent":{"return_values":{"output":"Hello, Bob! How can I assist you today?"},"log":"Hello, Bob! How can I assist you today?","type":"AgentFinish"}},"type":"ai","example":false},{"content":"whats my name? respond in spanish","additional_kwargs":{},"type":"human","example":false},{"content":"Tu nombre es Bob.","additional_kwargs":{"agent":{"return_values":{"output":"Tu nombre es Bob."},"log":"Tu nombre es Bob.","type":"AgentFinish"}},"type":"ai","example":false}]}'
+b'{"values":[{"content":"hi! my name is bob","additional_kwargs":{},"type":"human","example":false},{"content":"Hello, Bob! How can I assist you today?","additional_kwargs":{"agent":{"return_values":{"output":"Hello, Bob! How can I assist you today?"},"log":"Hello, Bob! How can I assist you today?","type":"AgentFinish"}},"type":"ai","example":false},{"content":"whats my name? respond in spanish","additional_kwargs":{},"type":"human","example":false},{"content":"Tu nombre es Bob.","additional_kwargs":{"agent":{"return_values":{"output":"Tu nombre es Bob."},"log":"Tu nombre es Bob.","type":"AgentFinish"}},"type":"ai","example":false}],"next":[]}'
 ```
 
 ## Stream

--- a/backend/app/api/runs.py
+++ b/backend/app/api/runs.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence
+from typing import Any, Dict, Optional, Sequence, Union
 
 import langsmith.client
 from fastapi import APIRouter, BackgroundTasks, HTTPException
@@ -24,7 +24,7 @@ class CreateRunPayload(BaseModel):
     """Payload for creating a run."""
 
     thread_id: str
-    input: Optional[Sequence[AnyMessage]] = Field(default_factory=list)
+    input: Optional[Union[Sequence[AnyMessage], Dict[str, Any]]] = Field(default_factory=dict)
     config: Optional[RunnableConfig] = None
 
 

--- a/backend/app/api/runs.py
+++ b/backend/app/api/runs.py
@@ -24,7 +24,9 @@ class CreateRunPayload(BaseModel):
     """Payload for creating a run."""
 
     thread_id: str
-    input: Optional[Union[Sequence[AnyMessage], Dict[str, Any]]] = Field(default_factory=dict)
+    input: Optional[Union[Sequence[AnyMessage], Dict[str, Any]]] = Field(
+        default_factory=dict
+    )
     config: Optional[RunnableConfig] = None
 
 

--- a/backend/app/api/threads.py
+++ b/backend/app/api/threads.py
@@ -1,4 +1,4 @@
-from typing import Annotated, List, Sequence
+from typing import Annotated, Any, Dict, List, Sequence, Union
 from uuid import uuid4
 
 from fastapi import APIRouter, HTTPException, Path
@@ -21,10 +21,10 @@ class ThreadPutRequest(BaseModel):
     assistant_id: str = Field(..., description="The ID of the assistant to use.")
 
 
-class ThreadMessagesPostRequest(BaseModel):
-    """Payload for adding messages to a thread."""
+class ThreadPostRequest(BaseModel):
+    """Payload for adding state to a thread."""
 
-    messages: Sequence[AnyMessage]
+    values: Union[Sequence[AnyMessage], Dict[str, Any]]
 
 
 @router.get("/")
@@ -33,23 +33,23 @@ async def list_threads(opengpts_user_id: OpengptsUserId) -> List[Thread]:
     return await storage.list_threads(opengpts_user_id)
 
 
-@router.get("/{tid}/messages")
-async def get_thread_messages(
+@router.get("/{tid}/state")
+async def get_thread_state(
     opengpts_user_id: OpengptsUserId,
     tid: ThreadID,
 ):
-    """Get all messages for a thread."""
-    return await storage.get_thread_messages(opengpts_user_id, tid)
+    """Get state for a thread."""
+    return await storage.get_thread_state(opengpts_user_id, tid)
 
 
-@router.post("/{tid}/messages")
-async def add_thread_messages(
+@router.post("/{tid}/state")
+async def add_thread_state(
     opengpts_user_id: OpengptsUserId,
     tid: ThreadID,
-    payload: ThreadMessagesPostRequest,
+    payload: ThreadPostRequest,
 ):
-    """Add messages to a thread."""
-    return await storage.post_thread_messages(opengpts_user_id, tid, payload.messages)
+    """Add state to a thread."""
+    return await storage.update_thread_state(opengpts_user_id, tid, payload.values)
 
 
 @router.get("/{tid}/history")

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -1,7 +1,8 @@
 from datetime import datetime, timezone
-from typing import List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 from langchain_core.messages import AnyMessage
+from langchain_core.runnables import RunnableConfig
 
 from app.agent import AgentType, get_agent_executor
 from app.lifespan import get_pg_pool
@@ -98,22 +99,22 @@ async def get_thread(user_id: str, thread_id: str) -> Optional[Thread]:
         )
 
 
-async def get_thread_messages(user_id: str, thread_id: str):
-    """Get all messages for a thread."""
+async def get_thread_state(user_id: str, thread_id: str):
+    """Get state for a thread."""
     app = get_agent_executor([], AgentType.GPT_35_TURBO, "", False)
     state = await app.aget_state({"configurable": {"thread_id": thread_id}})
     return {
-        "messages": state.values,
-        "resumeable": bool(state.next),
+        "values": state.values,
+        "next": state.next,
     }
 
 
-async def post_thread_messages(
-    user_id: str, thread_id: str, messages: Sequence[AnyMessage]
+async def update_thread_state(
+    user_id: str, thread_id: str, values: Union[Sequence[AnyMessage], Dict[str, Any]]
 ):
-    """Add messages to a thread."""
+    """Add state to a thread."""
     app = get_agent_executor([], AgentType.GPT_35_TURBO, "", False)
-    await app.aupdate_state({"configurable": {"thread_id": thread_id}}, messages)
+    await app.aupdate_state({"configurable": {"thread_id": thread_id}}, values)
 
 
 async def get_thread_history(user_id: str, thread_id: str):
@@ -122,7 +123,7 @@ async def get_thread_history(user_id: str, thread_id: str):
     return [
         {
             "values": c.values,
-            "resumeable": bool(c.next),
+            "next": c.next,
             "config": c.config,
             "parent": c.parent_config,
         }

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -2,7 +2,6 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence, Union
 
 from langchain_core.messages import AnyMessage
-from langchain_core.runnables import RunnableConfig
 
 from app.agent import AgentType, get_agent_executor
 from app.lifespan import get_pg_pool

--- a/backend/tests/unit_tests/app/test_app.py
+++ b/backend/tests/unit_tests/app/test_app.py
@@ -112,7 +112,7 @@ async def test_threads() -> None:
 
         response = await client.get(f"/threads/{tid}/state", headers=headers)
         assert response.status_code == 200
-        assert response.json() == {"values": {}, "next": ()}
+        assert response.json() == {"values": [], "next": []}
 
         response = await client.get("/threads/", headers=headers)
 

--- a/backend/tests/unit_tests/app/test_app.py
+++ b/backend/tests/unit_tests/app/test_app.py
@@ -110,9 +110,9 @@ async def test_threads() -> None:
         )
         assert response.status_code == 200, response.text
 
-        response = await client.get(f"/threads/{tid}/messages", headers=headers)
+        response = await client.get(f"/threads/{tid}/state", headers=headers)
         assert response.status_code == 200
-        assert response.json() == {"messages": [], "resumeable": False}
+        assert response.json() == {"values": {}, "next": ()}
 
         response = await client.get("/threads/", headers=headers)
 

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -25,7 +25,7 @@ function usePrevious<T>(value: T): T | undefined {
 
 export function Chat(props: ChatProps) {
   const { chatId } = useParams();
-  const { messages, resumeable } = useChatMessages(
+  const { messages, next } = useChatMessages(
     chatId ?? null,
     props.stream,
     props.stopStream,
@@ -71,7 +71,7 @@ export function Chat(props: ChatProps) {
           An error has occurred. Please try again.
         </div>
       )}
-      {resumeable && props.stream?.status !== "inflight" && (
+      {next.length > 0 && props.stream?.status !== "inflight" && (
         <div
           className="flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-800 ring-1 ring-inset ring-yellow-600/20 cursor-pointer"
           onClick={() => props.startStream(null, currentChat.thread_id)}

--- a/frontend/src/hooks/useChatMessages.ts
+++ b/frontend/src/hooks/useChatMessages.ts
@@ -2,16 +2,16 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Message } from "./useChatList";
 import { StreamState, mergeMessagesById } from "./useStreamState";
 
-async function getMessages(threadId: string) {
-  const { messages, resumeable } = await fetch(
-    `/threads/${threadId}/messages`,
+async function getState(threadId: string) {
+  const { values, next } = await fetch(
+    `/threads/${threadId}/state`,
     {
       headers: {
         Accept: "application/json",
       },
     },
   ).then((r) => r.json());
-  return { messages, resumeable };
+  return { values, next };
 }
 
 function usePrevious<T>(value: T): T | undefined {
@@ -26,17 +26,17 @@ export function useChatMessages(
   threadId: string | null,
   stream: StreamState | null,
   stopStream?: (clear?: boolean) => void,
-): { messages: Message[] | null; resumeable: boolean } {
+): { messages: Message[] | null; next: string[] } {
   const [messages, setMessages] = useState<Message[] | null>(null);
-  const [resumeable, setResumeable] = useState(false);
+  const [next, setNext] = useState<string[]>([]);
   const prevStreamStatus = usePrevious(stream?.status);
 
   useEffect(() => {
     async function fetchMessages() {
       if (threadId) {
-        const { messages, resumeable } = await getMessages(threadId);
-        setMessages(messages);
-        setResumeable(resumeable);
+        const { values, next } = await getState(threadId);
+        setMessages(values);
+        setNext(next);
       }
     }
 
@@ -50,15 +50,15 @@ export function useChatMessages(
   useEffect(() => {
     async function fetchMessages() {
       if (threadId) {
-        const { messages, resumeable } = await getMessages(threadId);
-        setMessages(messages);
-        setResumeable(resumeable);
+        const { values, next } = await getState(threadId);
+        setMessages(values);
+        setNext(next);
         stopStream?.(true);
       }
     }
 
     if (prevStreamStatus === "inflight" && stream?.status !== "inflight") {
-      setResumeable(false);
+      setNext([]);
       fetchMessages();
     }
 
@@ -68,8 +68,8 @@ export function useChatMessages(
   return useMemo(
     () => ({
       messages: mergeMessagesById(messages, stream?.messages),
-      resumeable,
+      next,
     }),
-    [messages, stream?.messages, resumeable],
+    [messages, stream?.messages, next],
   );
 }

--- a/frontend/src/hooks/useChatMessages.ts
+++ b/frontend/src/hooks/useChatMessages.ts
@@ -3,14 +3,11 @@ import { Message } from "./useChatList";
 import { StreamState, mergeMessagesById } from "./useStreamState";
 
 async function getState(threadId: string) {
-  const { values, next } = await fetch(
-    `/threads/${threadId}/state`,
-    {
-      headers: {
-        Accept: "application/json",
-      },
+  const { values, next } = await fetch(`/threads/${threadId}/state`, {
+    headers: {
+      Accept: "application/json",
     },
-  ).then((r) => r.json());
+  }).then((r) => r.json());
   return { values, next };
 }
 


### PR DESCRIPTION
### Summary
Currently, the OpenGPTs backend only implements `MessageGraph`. Implementing `StateGraph` in the backend demonstrates the ability to support arbitrary graphs within OpenGPTs. Migrating the current usage of `MessageGraph` to `StateGraph` is the first step.

Changes in this PR are adopted from [this PR](https://github.com/langchain-ai/opengpts/pull/257).

### Implementation
1. Rename internal variables and update docstrings: `messages` --> `values`.
2. Add support for `Dict[str, Any]` agent state type: `Sequence[AnyMessage]` --> `Union[Sequence[AnyMessage], Dict[str, Any]]`.
3. Breaking API changes to rename interfaces to be agnostic to a agent state type.

### Breaking API Changes
1. `GET /threads/<tid>/messages` --> `GET /threads/<tid>/state`
        Response: `{"messages": [...], ...}` --> `{"values": [...], "next": []}`
2. `POST /threads/<tid>/messages` --> `POST /threads/<tid>/state`
        Body: `{"messages": [...]}` --> `{"values": [...]}`

### To Do
- [ ] ~Migrate `get_chatbot_executor()` to use `StateGraph`~
- [ ] ~Migrate `get_retrieval_executor()` to use `StateGraph`~
- [ ] ~Migrate `get_google_agent_executor()` to use `StateGraph`~
- [ ] ~Migrate `get_openai_agent_executor()` to use `StateGraph`~
- [ ] ~Migrate `get_xml_agent_executor()` to use `StateGraph`~

Note: This PR can be merged without completing these to-do's.
