### PR TITLE
Fix thread state 500 error (when Retrieval tool is used)

### DIFF
--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -107,6 +107,7 @@ async def get_thread_state(*, user_id: str, thread_id: str, assistant_id: str):
             "configurable": {
                 **assistant["config"]["configurable"],
                 "thread_id": thread_id,
+                "assistant_id": assistant_id,
             }
         }
     )
@@ -130,6 +131,7 @@ async def update_thread_state(
             "configurable": {
                 **assistant["config"]["configurable"],
                 **config["configurable"],
+                "assistant_id": assistant_id,
             }
         },
         values,
@@ -151,6 +153,7 @@ async def get_thread_history(*, user_id: str, thread_id: str, assistant_id: str)
                 "configurable": {
                     **assistant["config"]["configurable"],
                     "thread_id": thread_id,
+                    "assistant_id": assistant_id,
                 }
             }
         )


### PR DESCRIPTION
Without passing `assistant_id` (in `configurable`) to `aget_state`, `aupdate_state` and `aget_state_history`, the following exception is raised:

`ValueError: Both assistant_id and thread_id must be provided if Retrieval tool is used`.

This happens when Retrieval tool is being used.
