### PR TITLE
[candidate_isaac] opengpts: ingest progress bar and python eval tool

### DIFF
--- a/backend/app/api/runs.py
+++ b/backend/app/api/runs.py
@@ -78,7 +78,21 @@ async def stream_run(
     """Create a run."""
     input_, config = await _run_input_and_config(payload, user["user_id"])
 
-    return EventSourceResponse(to_sse(astream_state(agent, input_, config)))
+    # DEBUG When being rate limitted, skip generating actual events.
+    async def fake_event_stream():
+        import orjson
+
+        for x in range(3):
+            yield {
+                "event": "metadata",
+                "data": orjson.dumps(
+                    {"run_id": f"irothschild debug fake run id {x}"}
+                ).decode(),
+            }
+
+    return EventSourceResponse(fake_event_stream())
+
+    # return EventSourceResponse(to_sse(astream_state(agent, input_, config)))
 
 
 @router.get("/input_schema")

--- a/backend/app/ingest.py
+++ b/backend/app/ingest.py
@@ -6,6 +6,7 @@ into a vector store.
 This code should be agnostic to how the blob got generated; i.e., it does not
 know about server/uploading etc.
 """
+
 from typing import List
 
 from langchain.text_splitter import TextSplitter

--- a/backend/app/upload.py
+++ b/backend/app/upload.py
@@ -87,7 +87,7 @@ class IngestRunnable(RunnableSerializable[BinaryIO, List[str]]):
     assistant_id: Optional[str]
     thread_id: Optional[str]
     """Ingested documents will be associated with assistant_id or thread_id.
-    
+
     ID is used as the namespace, and is filtered on at query time.
     """
 
@@ -108,14 +108,16 @@ class IngestRunnable(RunnableSerializable[BinaryIO, List[str]]):
         self, input: BinaryIO, config: Optional[RunnableConfig] = None
     ) -> List[str]:
         blob = _convert_ingestion_input_to_blob(input)
-        out = ingest_blob(
-            blob,
-            MIMETYPE_BASED_PARSER,
-            self.text_splitter,
-            self.vectorstore,
-            self.namespace,
-        )
-        return out
+        # DEBUG: Being Rate Limitted, so skipping this step
+        return ["irothschild debug, UploadRunnable invoke dummy response"]
+        # out = ingest_blob(
+        #     blob,
+        #     MIMETYPE_BASED_PARSER,
+        #     self.text_splitter,
+        #     self.vectorstore,
+        #     self.namespace,
+        # )
+        # return out
 
 
 PG_CONNECTION_STRING = PGVector.connection_string_from_db_params(

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,12 +42,34 @@ function App(props: { edit?: boolean }) {
         }, new FormData());
         formData.append(
           "config",
-          JSON.stringify({ configurable: { thread_id } }),
+          JSON.stringify({ configurable: { thread_id, show_progress_bar: true } }),
         );
-        await fetch(`/ingest`, {
-          method: "POST",
-          body: formData,
+        const response = await fetch(`/ingest`, {
+            method: "POST",
+            body: formData,
         });
+        if (response.body instanceof ReadableStream) {
+          let total = formData.getAll("files").length
+          let progress = 0;
+
+          const reader = response.body.getReader();
+          reader.read().then(function read_progress({ done, value }) {
+            if (done) {
+              return;
+            }
+            // If the server understands the progress bar, it will send messages like
+            // [0, msg0], [1, msg1], ...
+            // Check to make sure we are receiving well formed responses before
+            // printing progress info.
+            const data = new TextDecoder().decode(value);
+            const dataJson = JSON.parse(data);
+            if (dataJson instanceof Array && dataJson.length == 2 && typeof dataJson[0] === 'number') {
+              progress += 1;
+              console.log(`Progress ${progress} / ${total} (Data: ${data})`);
+            }
+            reader.read().then(read_progress);
+          });
+        }
       }
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tools/eval_tool/eval_tool.py
+++ b/tools/eval_tool/eval_tool.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+
+import click
+import pathlib
+import docker
+import tempfile
+import string
+import shutil
+import time
+
+# We need to install a set of relevant packages so that our users can use
+# the python we've installed for them. If we were working with traditional
+# python environments, we might require our users to specify a
+# `requirements.txt` file to enumerate their dependencies. This is robust from
+# an infra perspective, but most likely places too high a burden on Python code
+# generators at the moment. Controlling our python environment also has
+# security benefits, but requires us to manually add new capabilities if our
+# users supply Python sources with libraries we have not installed on our
+# testbed.
+DOCKERFILE_TEMPLATE = """
+FROM $base_image
+
+# Setup working directory
+RUN mkdir -p $workdir
+WORKDIR $workdir
+RUN chown $user:$group $workdir
+
+# Copy workload into place
+ADD $workload $workdir/$workload
+
+# Install python
+RUN apk add python3
+
+# Set user identity
+USER $user:$group
+
+# Run workload
+CMD python $workdir/$workload
+"""
+
+
+@click.command()
+@click.argument("workload", metavar="<workload.py>", type=click.Path(exists=True))
+def eval_tool(workload: pathlib.Path):
+    workload = pathlib.Path(workload).absolute()
+    if not workload.is_file():
+        raise click.UsageError(f"Filename {workload} does is not a regular file.")
+    if workload.suffix != ".py":
+        raise click.UsageError(f"Filename {workload} is not a python file.")
+    client = docker.from_env()
+
+    # In order to add our workload file to the image, we need to provide the
+    # relative path from the Dockerfile context to the workload file, and the
+    # file must be in a subtree of the Dockerfile context dir. The Docker SDK
+    # provides the ability to pass a fileobj directly, however, it generates a
+    # tempfile location for the Dockerfile context, and so we cannot place our
+    # target file inside of the context. Therefore, we generate a tempfile of
+    # our own, and assemble the image that way.
+    click.echo(f"Building image for {workload}")
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_dir_path = pathlib.Path(tmp_dir)
+        shutil.copy(workload, tmp_dir_path.joinpath("workload.py"))
+        with open(tmp_dir_path.joinpath("Dockerfile"), mode="wb") as df:
+            df.write(
+                string.Template(DOCKERFILE_TEMPLATE)
+                .substitute(
+                    base_image="alpine",
+                    workdir="/workdir",
+                    workload="workload.py",
+                    user="nobody",
+                    group="nobody",
+                )
+                .encode()
+            )
+        image, _ = client.images.build(path=tmp_dir, rm=True)
+    click.echo(f"Image: {image.id}")
+
+    container_opts = {
+        # Clean up container on exit
+        "remove": True,
+        # Create unique cgroup for this container
+        "cgroupns": "private",
+        # Do not consume too many resources
+        "mem_limit": "4gb",
+        # Do not give extended privileges to the container
+        "privileged": False,
+        "security_opt": ["no-new-privileges=true"],
+        # Mount root filesystem as readonly
+        "read_only": True,
+    }
+    click.echo("Running container")
+    start = time.time()
+    output = client.containers.run(image, **container_opts)
+    end = time.time()
+    click.echo("Done")
+    click.echo("========")
+    click.echo(output)
+    click.echo("========")
+    click.echo(f"({end-start})")
+
+
+if __name__ == "__main__":
+    eval_tool()


### PR DESCRIPTION
### A couple of notes
- Realistically, these should be separate PRs, but keeping them together to simplify things.
- There are lots of test changes included here, this is because the rate limit on the free version of OpenAI API is low enough that I cannot get any real-life tests to run.
- There are some formatting changes that my editor added which should have been removed. Once I get the hang of `git add --interactive` I'll skip those ;) 

### In this diff
1. For the `/ingest` endpoint on the OpenGPTs server, stream updates back to the caller as each file completes uploading.
2. Unrelated, add a script which runs a provided Python source in a simple and secure Docker container.

# `/ingest`

### Considerations

The key change in this section is to return a `StreamingResponse` around the `ingest_runnable.abatch_as_completed` async generator. In `server.py`:
```python
return StreamingResponse(
  decode_ingestion_response(
    ingest_runnable.abatch_as_completed(
      [file.file for file in files], config
    )
  )
)
```

### Test Plan
Open OpenGPTs frontend in browser. Navigate to existing Thread and upload multiple files along with a dummy message. Observe that progress information is printed via. `console.log`.

Modify source to omit `show_progress_bar` on the client side, and notice how no progress info is printed.

Modify source to use previous and new versions of server side to show that providing `show_progress_bar` to server which does not understand it, does not cause any changes.

For a smaller test case, you can use the following script to make an `/ingest` request:
```typescript
async function runTest() {
  const url = new URL("http://localhost:5173/ingest?user=me");
  const formData = make_form_data(true);
  console.log(formData);
  return await make_request(url, formData);
}

function make_form_data(show_progress_bar: Boolean): FormData {
  // Assemble request with assistant ID, optional progress bar flag, and two fake files
  let formData = new FormData()
  let fileA = new File(["AAA. This is the content for file A\n"], "A", { type: "text/plain", });
  let fileB = new File(["BBB. This is the content for file B\n"], "B", { type: "text/plain", });
  formData.append("files", fileA);
  formData.append("files", fileB);
  formData.append("config", JSON.stringify({configurable: { assistant_id: "f08f6330-c5a2-42c7-8e7c-80aade10b1c5", show_progress_bar: show_progress_bar }}));

  return formData
}

async function make_request(url: URL, formData: FormData) {
  const response = await fetch(url, {
    method: "POST",
    body: formData,
  });
  if (response.body instanceof ReadableStream) {
    let total = formData.getAll("files").length
    let progress = 0;

    const reader = response.body.getReader();
    reader.read().then(function read_progress({ done, value }) {
      if (!done) {
        // If the server understands the progress bar, it will send messages like
        // [0, msg0], [1, msg1], ...
        // Check to make sure we are receiving well formed responses before
        // printing progress info.
        const data = new TextDecoder().decode(value);
        const dataJson = JSON.parse(data);
        if (dataJson instanceof Array && dataJson.length == 2 && typeof dataJson[0] === 'number') {
          progress += 1
          console.log(`Progress ${progress} / ${total} (Data: ${data})`)
        }
        reader.read().then(read_progress);
      }
    });
  }
  return response
}

runTest().then(data => console.log(data));
```

# Python Source

### Considerations

The main tradeoff in this script is how the Docker container gets created. There are two basic approaches that come to mind:
1. We build a dedicated scheduler, which at its most basic level will be a server which takes incoming requests, creates and runs containers as desired, potentially on different hosts, keeps track of the state of the current workload and cleans up after itself. This has advantages like (a) can better control resource usage by killing / cleaning long-running containers and (b) better separation of concerns and potential for optimization (e.g. can share python implementation across containers, instead of re-installing on each image). The downside is that realistically we do not want to run our own scheduler unless we have a really good reason to do so because they are complex and heavy.
2. We run containers in an ad-hoc way. Each time we receive a request, we start from scratch, build an image, run the workload, and wait for the result. This is dead simple, but limits our ability to do resource management, intelligent scheduling of workloads onto free hosts, and have monitors for basic failures like stuck jobs.

For this diff, I implemented the ad-hoc strategy because we don't have a compelling reason to add the complexity of the full server approach, and the ad-hoc approach is portable and flexible.

### Test Plan
Provide the following Python source in e.g. `test.py`, and observe that easy escalations to `root` are not possible.
```python
import os
import pwd
import subprocess

user = pwd.getpwuid(os.getuid())
print(f"This is a test being run by user {user.pw_name} ({user.pw_uid}:{user.pw_gid})")

try:
    print(subprocess.check_output("su -", shell=True, text=True))
except Exception as e:
    print(f"Failed to become root via subprocess: {e}")

try:
    os.setuid(1)
except Exception as e:
    print(f"Failed to become root via os.setuid(1): {e}")
```