### PR TITLE
Deleting assistants & attaching orphaned threads to new assistants

### DIFF
--- a/backend/app/api/assistants.py
+++ b/backend/app/api/assistants.py
@@ -75,3 +75,13 @@ async def upsert_assistant(
         config=payload.config,
         public=payload.public,
     )
+
+
+@router.delete("/{aid}")
+async def delete_assistant(
+    user: AuthedUser,
+    aid: AssistantID,
+):
+    """Delete an assistant by ID."""
+    await storage.delete_assistant(user["user_id"], aid)
+    return {"status": "ok"}

--- a/backend/app/api/threads.py
+++ b/backend/app/api/threads.py
@@ -44,10 +44,13 @@ async def get_thread_state(
     thread = await storage.get_thread(user["user_id"], tid)
     if not thread:
         raise HTTPException(status_code=404, detail="Thread not found")
+    assistant = await storage.get_assistant(user["user_id"], thread["assistant_id"])
+    if not assistant:
+        raise HTTPException(status_code=400, detail="Thread has no assistant")
     return await storage.get_thread_state(
         user_id=user["user_id"],
         thread_id=tid,
-        assistant_id=thread["assistant_id"],
+        assistant=assistant,
     )
 
 
@@ -61,11 +64,14 @@ async def add_thread_state(
     thread = await storage.get_thread(user["user_id"], tid)
     if not thread:
         raise HTTPException(status_code=404, detail="Thread not found")
+    assistant = await storage.get_assistant(user["user_id"], thread["assistant_id"])
+    if not assistant:
+        raise HTTPException(status_code=400, detail="Thread has no assistant")
     return await storage.update_thread_state(
         payload.config or {"configurable": {"thread_id": tid}},
         payload.values,
         user_id=user["user_id"],
-        assistant_id=thread["assistant_id"],
+        assistant=assistant,
     )
 
 
@@ -78,10 +84,13 @@ async def get_thread_history(
     thread = await storage.get_thread(user["user_id"], tid)
     if not thread:
         raise HTTPException(status_code=404, detail="Thread not found")
+    assistant = await storage.get_assistant(user["user_id"], thread["assistant_id"])
+    if not assistant:
+        raise HTTPException(status_code=400, detail="Thread has no assistant")
     return await storage.get_thread_history(
         user_id=user["user_id"],
         thread_id=tid,
-        assistant_id=thread["assistant_id"],
+        assistant=assistant,
     )
 
 

--- a/backend/app/lifespan.py
+++ b/backend/app/lifespan.py
@@ -20,6 +20,12 @@ async def _init_connection(conn) -> None:
         schema="pg_catalog",
     )
     await conn.set_type_codec(
+        "jsonb",
+        encoder=lambda v: orjson.dumps(v).decode(),
+        decoder=orjson.loads,
+        schema="pg_catalog",
+    )
+    await conn.set_type_codec(
         "uuid", encoder=lambda v: str(v), decoder=lambda v: v, schema="pg_catalog"
     )
 

--- a/backend/app/schema.py
+++ b/backend/app/schema.py
@@ -41,3 +41,4 @@ class Thread(TypedDict):
     """The name of the thread."""
     updated_at: datetime
     """The last time the thread was updated."""
+    metadata: Optional[dict]

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -208,3 +208,13 @@ async def delete_thread(user_id: str, thread_id: str):
             thread_id,
             user_id,
         )
+
+
+async def delete_assistant(user_id: str, assistant_id: str) -> None:
+    """Delete an assistant by ID."""
+    async with get_pg_pool().acquire() as conn:
+        await conn.execute(
+            "DELETE FROM assistant WHERE assistant_id = $1 AND user_id = $2",
+            assistant_id,
+            user_id,
+        )

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -92,15 +92,14 @@ async def get_thread(user_id: str, thread_id: str) -> Optional[Thread]:
         )
 
 
-async def get_thread_state(*, user_id: str, thread_id: str, assistant_id: str):
+async def get_thread_state(*, user_id: str, thread_id: str, assistant: Assistant):
     """Get state for a thread."""
-    assistant = await get_assistant(user_id, assistant_id)
     state = await agent.aget_state(
         {
             "configurable": {
                 **assistant["config"]["configurable"],
                 "thread_id": thread_id,
-                "assistant_id": assistant_id,
+                "assistant_id": assistant["assistant_id"],
             }
         }
     )
@@ -115,25 +114,23 @@ async def update_thread_state(
     values: Union[Sequence[AnyMessage], dict[str, Any]],
     *,
     user_id: str,
-    assistant_id: str,
+    assistant: Assistant,
 ):
     """Add state to a thread."""
-    assistant = await get_assistant(user_id, assistant_id)
     await agent.aupdate_state(
         {
             "configurable": {
                 **assistant["config"]["configurable"],
                 **config["configurable"],
-                "assistant_id": assistant_id,
+                "assistant_id": assistant["assistant_id"],
             }
         },
         values,
     )
 
 
-async def get_thread_history(*, user_id: str, thread_id: str, assistant_id: str):
+async def get_thread_history(*, user_id: str, thread_id: str, assistant: Assistant):
     """Get the history of a thread."""
-    assistant = await get_assistant(user_id, assistant_id)
     return [
         {
             "values": c.values,
@@ -146,7 +143,7 @@ async def get_thread_history(*, user_id: str, thread_id: str, assistant_id: str)
                 "configurable": {
                     **assistant["config"]["configurable"],
                     "thread_id": thread_id,
-                    "assistant_id": assistant_id,
+                    "assistant_id": assistant["assistant_id"],
                 }
             }
         )

--- a/backend/migrations/000004_add_metadata_to_thread.down.sql
+++ b/backend/migrations/000004_add_metadata_to_thread.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE thread
+DROP COLUMN metadata;

--- a/backend/migrations/000004_add_metadata_to_thread.up.sql
+++ b/backend/migrations/000004_add_metadata_to_thread.up.sql
@@ -1,5 +1,5 @@
 ALTER TABLE thread
-ADD COLUMN metadata JSON;
+ADD COLUMN metadata JSONB;
 
 UPDATE thread
 SET metadata = json_build_object(

--- a/backend/migrations/000004_add_metadata_to_thread.up.sql
+++ b/backend/migrations/000004_add_metadata_to_thread.up.sql
@@ -1,0 +1,9 @@
+ALTER TABLE thread
+ADD COLUMN metadata JSON;
+
+UPDATE thread
+SET metadata = json_build_object(
+    'assistant_type', (SELECT config->'configurable'->>'type'
+                 FROM assistant
+                 WHERE assistant.assistant_id = thread.assistant_id)
+);

--- a/backend/tests/unit_tests/app/test_app.py
+++ b/backend/tests/unit_tests/app/test_app.py
@@ -112,7 +112,14 @@ async def test_threads() -> None:
         assert response.status_code == 200
         assert [
             _project(d, exclude_keys=["updated_at", "user_id"]) for d in response.json()
-        ] == [{"assistant_id": aid, "name": "bobby", "thread_id": tid}]
+        ] == [
+            {
+                "assistant_id": aid,
+                "name": "bobby",
+                "thread_id": tid,
+                "metadata": {"assistant_type": "chatbot"},
+            }
+        ]
 
         response = await client.put(
             f"/threads/{tid}",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,7 +21,7 @@ function App(props: { edit?: boolean }) {
   const navigate = useNavigate();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const { chats, createChat, deleteChat } = useChatList();
-  const { configs, saveConfig } = useConfigList();
+  const { configs, saveConfig, deleteConfig } = useConfigList();
   const { startStream, stopStream, stream } = useStreamState();
   const { configSchema, configDefaults } = useSchemas();
 
@@ -153,6 +153,7 @@ function App(props: { edit?: boolean }) {
           configs={configs}
           saveConfig={saveConfig}
           enterConfig={selectConfig}
+          deleteConfig={deleteConfig}
         />
       )}
       {!currentChat && assistantConfig && props.edit && (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,11 +16,12 @@ import { MessageWithFiles } from "./utils/formTypes.ts";
 import { useNavigate } from "react-router-dom";
 import { useThreadAndAssistant } from "./hooks/useThreadAndAssistant.ts";
 import { Message } from "./types.ts";
+import { OrphanChat } from "./components/OrphanChat.tsx";
 
 function App(props: { edit?: boolean }) {
   const navigate = useNavigate();
   const [sidebarOpen, setSidebarOpen] = useState(false);
-  const { chats, createChat, deleteChat } = useChatList();
+  const { chats, createChat, updateChat, deleteChat } = useChatList();
   const { configs, saveConfig, deleteConfig } = useConfigList();
   const { startStream, stopStream, stream } = useStreamState();
   const { configSchema, configDefaults } = useSchemas();
@@ -144,6 +145,9 @@ function App(props: { edit?: boolean }) {
     >
       {currentChat && assistantConfig && (
         <Chat startStream={startTurn} stopStream={stopStream} stream={stream} />
+      )}
+      {currentChat && !assistantConfig && (
+        <OrphanChat chat={currentChat} updateChat={updateChat} />
       )}
       {!currentChat && assistantConfig && !props.edit && (
         <NewChat

--- a/frontend/src/api/assistants.ts
+++ b/frontend/src/api/assistants.ts
@@ -14,3 +14,16 @@ export async function getAssistant(
     return null;
   }
 }
+
+export async function getAssistants(): Promise<Config[] | null> {
+  try {
+    const response = await fetch(`/assistants/`);
+    if (!response.ok) {
+      return null;
+    }
+    return (await response.json()) as Config[];
+  } catch (error) {
+    console.error("Failed to fetch assistants:", error);
+    return null;
+  }
+}

--- a/frontend/src/components/ChatList.tsx
+++ b/frontend/src/components/ChatList.tsx
@@ -139,7 +139,13 @@ export function ChatList(props: {
                     role="menuitem"
                     onClick={(event) => {
                       event.preventDefault();
-                      props.deleteChat(chat.thread_id);
+                      if (
+                        window.confirm(
+                          `Are you sure you want to delete chat "${chat.name}"?`,
+                        )
+                      ) {
+                        props.deleteChat(chat.thread_id);
+                      }
                     }}
                   >
                     Delete

--- a/frontend/src/components/ConfigList.tsx
+++ b/frontend/src/components/ConfigList.tsx
@@ -1,13 +1,14 @@
 import { TYPES } from "../constants";
 import { Config, ConfigListProps } from "../hooks/useConfigList";
 import { cn } from "../utils/cn";
-import { PencilSquareIcon } from "@heroicons/react/24/outline";
+import { PencilSquareIcon, TrashIcon } from "@heroicons/react/24/outline";
 import { Link } from "react-router-dom";
 
 function ConfigItem(props: {
   config: Config;
   currentConfig: Config | null;
   enterConfig: (id: string | null) => void;
+  deleteConfig: (id: string) => void;
 }) {
   return (
     <li key={props.config.assistant_id}>
@@ -50,6 +51,22 @@ function ConfigItem(props: {
         >
           <PencilSquareIcon />
         </Link>
+        <Link
+          className="w-5"
+          to="#"
+          onClick={(event) => {
+            event.preventDefault();
+            if (
+              window.confirm(
+                `Are you sure you want to delete bot "${props.config.name}?"`,
+              )
+            ) {
+              props.deleteConfig(props.config.assistant_id);
+            }
+          }}
+        >
+          <TrashIcon />
+        </Link>
       </div>
     </li>
   );
@@ -59,6 +76,7 @@ export function ConfigList(props: {
   configs: ConfigListProps["configs"];
   currentConfig: Config | null;
   enterConfig: (id: string | null) => void;
+  deleteConfig: (id: string) => void;
 }) {
   return (
     <>
@@ -74,6 +92,7 @@ export function ConfigList(props: {
               config={assistant}
               currentConfig={props.currentConfig}
               enterConfig={props.enterConfig}
+              deleteConfig={props.deleteConfig}
             />
           )) ?? (
           <li className="leading-6 p-2 animate-pulse font-black text-gray-400 text-lg">
@@ -94,6 +113,7 @@ export function ConfigList(props: {
               config={assistant}
               currentConfig={props.currentConfig}
               enterConfig={props.enterConfig}
+              deleteConfig={props.deleteConfig}
             />
           )) ?? (
           <li className="leading-6 p-2 animate-pulse font-black text-gray-400 text-lg">

--- a/frontend/src/components/NewChat.tsx
+++ b/frontend/src/components/NewChat.tsx
@@ -15,6 +15,7 @@ interface NewChatProps extends ConfigListProps {
   configSchema: Schemas["configSchema"];
   configDefaults: Schemas["configDefaults"];
   enterConfig: (id: string | null) => void;
+  deleteConfig: (id: string) => Promise<void>;
   startChat: (
     config: ConfigInterface,
     message: MessageWithFiles,
@@ -39,11 +40,12 @@ export function NewChat(props: NewChatProps) {
       )}
     >
       <div className="flex-1 flex flex-col md:flex-row lg:items-stretch self-stretch">
-        <div className="w-72 border-r border-gray-200 pr-6">
+        <div className="md:w-72 border-r border-gray-200 pr-6">
           <ConfigList
             configs={props.configs}
             currentConfig={assistantConfig}
             enterConfig={(id) => navigator(`/assistant/${id}`)}
+            deleteConfig={props.deleteConfig}
           />
         </div>
 

--- a/frontend/src/components/OrphanChat.tsx
+++ b/frontend/src/components/OrphanChat.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from "react";
+import { Config } from "../hooks/useConfigList";
+import { Chat } from "../types";
+import { getAssistants } from "../api/assistants";
+import { useThreadAndAssistant } from "../hooks/useThreadAndAssistant";
+
+export function OrphanChat(props: {
+  chat: Chat;
+  updateChat: (
+    name: string,
+    thread_id: string,
+    assistant_id: string | null,
+  ) => Promise<Chat>;
+}) {
+  const [newConfigId, setNewConfigId] = useState(null as string | null);
+  const [configs, setConfigs] = useState<Config[]>([]);
+  const { invalidateChat } = useThreadAndAssistant();
+
+  const update = async () => {
+    if (!newConfigId) {
+      alert("Please select a bot.");
+      return;
+    }
+    const updatedChat = await props.updateChat(
+      props.chat.thread_id,
+      props.chat.name,
+      newConfigId,
+    );
+    invalidateChat(updatedChat.thread_id);
+  };
+
+  const botTypeToName = (botType: string) => {
+    switch (botType) {
+      case "chatbot":
+        return "Chatbot";
+      case "chat_retrieval":
+        return "RAG";
+      case "agent":
+        return "Assistant";
+      default:
+        return botType;
+    }
+  };
+
+  useEffect(() => {
+    async function fetchConfigs() {
+      const configs = await getAssistants();
+      const suitableConfigs = configs
+        ? configs.filter(
+            (config) =>
+              config.config.configurable?.type ===
+              props.chat.metadata?.assistant_type,
+          )
+        : [];
+      setConfigs(suitableConfigs);
+    }
+
+    fetchConfigs();
+  }, [props.chat.metadata?.assistant_type]);
+
+  return (
+    <div className="flex-1 flex flex-col items-stretch pb-[76px] pt-2">
+      {configs.length ? (
+        <form
+          onSubmit={async (e) => {
+            e.preventDefault();
+            await update();
+          }}
+          className="space-y-4 max-w-xl w-full px-4"
+        >
+          <div className="inline-flex items-center rounded-md bg-yellow-100 px-2 py-1 text-xs font-medium text-yellow-700">
+            This chat has no bot attached. To continue chatting, please attach a
+            bot.
+          </div>
+          <div className="flex flex-row flex-1">
+            <div className="relative flex flex-grow items-stretch focus-within:z-10">
+              <select
+                className="block w-full rounded-none rounded-l-md border-0 py-1.5 pl-4 text-gray-900 ring-1 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6 ring-inset ring-gray-300"
+                onChange={(event) => setNewConfigId(event.target.value)}
+              >
+                <option value="">Select a bot</option>
+                {configs.map((config, index) => (
+                  <option key={index} value={config.assistant_id}>
+                    {config.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <button
+              type="submit"
+              className="inline-flex items-center px-4 py-2 border border-transparent text-sm leading-5 font-medium rounded-r-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-600"
+            >
+              Save
+            </button>
+          </div>
+        </form>
+      ) : (
+        <div className="inline-flex items-center px-2 py-1">
+          <div className="rounded-md bg-yellow-100 px-2 py-1 text-xs font-medium text-yellow-700">
+            This chat has no bot attached. To continue chatting, you need to
+            attach a bot. However, there are no suitable bots available for this
+            chat. Please create a new bot with type{" "}
+            {botTypeToName(props.chat.metadata?.assistant_type as string)} and
+            try again.
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useChatList.ts
+++ b/frontend/src/hooks/useChatList.ts
@@ -4,10 +4,11 @@ import { Chat } from "../types";
 
 export interface ChatListProps {
   chats: Chat[] | null;
-  createChat: (
+  createChat: (name: string, assistant_id: string) => Promise<Chat>;
+  updateChat: (
     name: string,
-    assistant_id: string,
-    thread_id?: string,
+    thread_id: string,
+    assistant_id: string | null,
   ) => Promise<Chat>;
   deleteChat: (thread_id: string) => Promise<void>;
 }
@@ -57,6 +58,23 @@ export function useChatList(): ChatListProps {
     return saved;
   }, []);
 
+  const updateChat = useCallback(
+    async (thread_id: string, name: string, assistant_id: string | null) => {
+      const response = await fetch(`/threads/${thread_id}`, {
+        method: "PUT",
+        body: JSON.stringify({ assistant_id, name }),
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+      });
+      const saved = await response.json();
+      setChats(saved);
+      return saved;
+    },
+    [],
+  );
+
   const deleteChat = useCallback(
     async (thread_id: string) => {
       await fetch(`/threads/${thread_id}`, {
@@ -73,6 +91,7 @@ export function useChatList(): ChatListProps {
   return {
     chats,
     createChat,
+    updateChat,
     deleteChat,
   };
 }

--- a/frontend/src/hooks/useConfigList.ts
+++ b/frontend/src/hooks/useConfigList.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useReducer } from "react";
 import orderBy from "lodash/orderBy";
+import { getAssistants } from "../api/assistants";
 
 export interface Config {
   assistant_id: string;
@@ -51,14 +52,10 @@ export function useConfigList(): ConfigListProps {
 
   useEffect(() => {
     async function fetchConfigs() {
-      const myConfigs = await fetch("/assistants/", {
-        headers: {
-          Accept: "application/json",
-        },
-      })
-        .then((r) => r.json())
-        .then((li) => li.map((c: Config) => ({ ...c, mine: true })));
-      setConfigs(myConfigs);
+      const assistants = await getAssistants();
+      setConfigs(
+        assistants ? assistants.map((c) => ({ ...c, mine: true })) : [],
+      );
     }
 
     fetchConfigs();

--- a/frontend/src/hooks/useConfigList.ts
+++ b/frontend/src/hooks/useConfigList.ts
@@ -30,6 +30,7 @@ export interface ConfigListProps {
     isPublic: boolean,
     assistantId?: string,
   ) => Promise<string>;
+  deleteConfig: (assistantId: string) => Promise<void>;
 }
 
 function configsReducer(
@@ -102,8 +103,22 @@ export function useConfigList(): ConfigListProps {
     [],
   );
 
+  const deleteConfig = useCallback(
+    async (assistantId: string): Promise<void> => {
+      await fetch(`/assistants/${assistantId}`, {
+        method: "DELETE",
+        headers: {
+          Accept: "application/json",
+        },
+      });
+      setConfigs((configs || []).filter((c) => c.assistant_id !== assistantId));
+    },
+    [configs],
+  );
+
   return {
     configs,
     saveConfig,
+    deleteConfig,
   };
 }

--- a/frontend/src/hooks/useThreadAndAssistant.ts
+++ b/frontend/src/hooks/useThreadAndAssistant.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 import { useParams } from "react-router-dom";
 import { getAssistant } from "../api/assistants";
 import { getThread } from "../api/threads";
@@ -6,6 +6,7 @@ import { getThread } from "../api/threads";
 export function useThreadAndAssistant() {
   // Extract route parameters
   const { chatId, assistantId } = useParams();
+  const queryClient = useQueryClient();
 
   // React Query to fetch chat details if chatId is present
   const { data: currentChat, isLoading: isLoadingChat } = useQuery(
@@ -28,10 +29,15 @@ export function useThreadAndAssistant() {
     },
   );
 
+  const invalidateChat = (chatId: string) => {
+    queryClient.invalidateQueries(["thread", chatId]);
+  };
+
   // Return both loading states, the chat data, and the assistant configuration
   return {
     currentChat,
     assistantConfig,
     isLoading: isLoadingChat || isLoadingAssistant,
+    invalidateChat,
   };
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -24,4 +24,5 @@ export interface Chat {
   thread_id: string;
   name: string;
   updated_at: string;
+  metadata: Record<string, unknown> | null;
 }


### PR DESCRIPTION
As agreed @nfcampos:

- Enables deleting assistants without automatically deleting associated threads.
- Adds metadata column to thread. Column stores the thread's original assistant type: `{"assistant_type": assistant["config"]["configurable"]["type"]}`
- Uses this metadata on the frontend to enable attaching threads to suitable assistants (@andrewnguonly this prevents the issue of deserialization by for example not allowing RAG's thread to be attached to Chatbot).

Ideally, we'd be able to show old messages in the UI for threads without assistants. But unfortunately the current state of things prevents this due to `get_thread_state` depending on the existence of an assistant. So, here's how the UI looks like:

[Screencast from 05-03-2024 11:34:11 AM.webm](https://github.com/langchain-ai/opengpts/assets/10211478/6312d436-7f4c-463a-8425-f8e57d634bd0)

