### PR TITLE
backend: Convert checkpointer.alist to async generator to fix async iteration in aget_state_history

### DIFF
--- a/backend/app/checkpoint.py
+++ b/backend/app/checkpoint.py
@@ -87,9 +87,10 @@ class AsyncPostgresCheckpoint(BasePostgresSaver):
         limit: Optional[int] = None,
     ) -> AsyncIterator[CheckpointTuple]:
         """List checkpoints from the database asynchronously."""
-        return self.async_postgres_saver.alist(
+        async for checkpoint in self.async_postgres_saver.alist(
             config, filter=filter, before=before, limit=limit
-        )
+        ):
+            yield checkpoint
 
     async def aget_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
         """Get a checkpoint tuple from the database asynchronously."""


### PR DESCRIPTION
## PR Description

This PR converts `checkpointer.alist` into an async generator by using async for and yield inside the function. With this change, `alist` immediately returns an async iterator, allowing `agent.aget_state_history()` to iterate over it directly without needing to await the coroutine.

## Relevant issues

https://github.com/langchain-ai/opengpts/issues/377

## Type

🐛 Bug Fix

## Changes

- Modified `checkpointer.alist` to use an async generator pattern python

## Tests
Tested the flow by calling `get_thread_history()` which internally calls `agent.aget_state_history()`, confirming that the async iteration now functions as expected without errors.

Thank you Team!